### PR TITLE
test: replace assert_equal true/false with assert/assert_not for minitest 6.0 compatibility

### DIFF
--- a/test/controllers/answers_controller_test.rb
+++ b/test/controllers/answers_controller_test.rb
@@ -21,21 +21,21 @@ class AnswersControllerTest < ActionDispatch::IntegrationTest
     post answers_path, params: {
       answer: { question_id: @question.id, selected_side: "debit", input_amount: 100 }
     }
-    assert_equal true, Answer.last.is_correct
+    assert Answer.last.is_correct
   end
 
   test "create saves is_correct false for wrong side" do
     post answers_path, params: {
       answer: { question_id: @question.id, selected_side: "credit", input_amount: 100 }
     }
-    assert_equal false, Answer.last.is_correct
+    assert_not Answer.last.is_correct
   end
 
   test "create saves is_correct false for wrong amount" do
     post answers_path, params: {
       answer: { question_id: @question.id, selected_side: "debit", input_amount: 999 }
     }
-    assert_equal false, Answer.last.is_correct
+    assert_not Answer.last.is_correct
   end
 
   test "create without selected_side renders question show" do


### PR DESCRIPTION
## Summary

- `assert_equal true, ...` → `assert ...` に置き換え
- `assert_equal false, ...` → `assert_not ...` に置き換え

## 背景

PR #42（minitest 5.x → 6.0 アップグレード）のコードレビューで指摘。minitest 6.0 では `assert_equal(nil, value)` が禁止されており、`true`/`false` の比較も `assert`/`assert_not` を使うスタイルが推奨される。

## 変更ファイル

- `test/controllers/answers_controller_test.rb`（3箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)